### PR TITLE
iOS 8 rotation bug built with Xcode 5

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -300,9 +300,13 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 #pragma mark - View Hierrarchy
 
 - (BOOL)shouldPerformOrientationTransform {
+#ifdef __IPHONE_8_0
 	BOOL isPreiOS8 = kCFCoreFoundationVersionNumber < kCFCoreFoundationVersionNumber_iOS_8_0;
 	// prior to iOS8 code needs to take care of rotation if it is being added to the window
 	return isPreiOS8 && [self.superview isKindOfClass:[UIWindow class]];
+#else
+	return YES;
+#endif
 }
 
 - (void)didMoveToSuperview {


### PR DESCRIPTION
The iOS 8 rotation problem only happens after Xcode 6.
Xcode 5 can still be used without building 64-bit code for app updates, until June 1, 2015.